### PR TITLE
fix: Rename remaining instances of "private address"

### DIFF
--- a/src/lib/DBCertificateStore.ts
+++ b/src/lib/DBCertificateStore.ts
@@ -17,27 +17,27 @@ export class DBCertificateStore extends CertificateStore {
 
   protected async saveData(
     serialization: ArrayBuffer,
-    subjectPrivateAddress: string,
+    subjectId: string,
     subjectCertificateExpiryDate: Date,
-    issuerPrivateAddress: string,
+    issuerId: string,
   ): Promise<void> {
     const record = this.repository.create({
       expiryDate: subjectCertificateExpiryDate,
-      issuerPrivateAddress,
+      issuerId,
       serialization: Buffer.from(serialization),
-      subjectPrivateAddress,
+      subjectId,
     });
     await this.repository.save(record);
   }
 
   protected async retrieveLatestSerialization(
-    subjectPrivateAddress: string,
-    issuerPrivateAddress: string,
+    subjectId: string,
+    issuerId: string,
   ): Promise<ArrayBuffer | null> {
     const where = {
       expiryDate: MoreThanOrEqual(new Date()),
-      issuerPrivateAddress,
-      subjectPrivateAddress,
+      issuerId,
+      subjectId,
     };
     const record = await this.repository.findOne({
       order: { expiryDate: 'DESC' },
@@ -47,14 +47,14 @@ export class DBCertificateStore extends CertificateStore {
   }
 
   protected async retrieveAllSerializations(
-    subjectPrivateAddress: string,
-    issuerPrivateAddress: string,
+    subjectId: string,
+    issuerId: string,
   ): Promise<readonly ArrayBuffer[]> {
     const records = await this.repository.find({
       where: {
         expiryDate: MoreThanOrEqual(new Date()),
-        issuerPrivateAddress,
-        subjectPrivateAddress,
+        issuerId,
+        subjectId,
       },
     });
     return records.map((record) => bufferToArray(record.serialization));

--- a/src/lib/DBPrivateKeyStore.ts
+++ b/src/lib/DBPrivateKeyStore.ts
@@ -17,16 +17,16 @@ export class DBPrivateKeyStore extends PrivateKeyStore {
     super();
   }
 
-  public async retrieveIdentityKey(privateAddress: string): Promise<CryptoKey | null> {
-    const keyData = await this.identityKeyRepository.findOneBy({ id: privateAddress });
+  public async retrieveIdentityKey(id: string): Promise<CryptoKey | null> {
+    const keyData = await this.identityKeyRepository.findOneBy({ id });
     return keyData ? derDeserializeRSAPrivateKey(keyData.derSerialization) : null;
   }
 
-  public async saveIdentityKey(privateAddress: string, privateKey: CryptoKey): Promise<void> {
+  public async saveIdentityKey(id: string, privateKey: CryptoKey): Promise<void> {
     const privateKeySerialized = await derSerializePrivateKey(privateKey);
     const privateKeyData = await this.identityKeyRepository.create({
       derSerialization: privateKeySerialized,
-      id: privateAddress,
+      id,
     });
     await this.identityKeyRepository.save(privateKeyData);
   }
@@ -34,14 +34,14 @@ export class DBPrivateKeyStore extends PrivateKeyStore {
   protected async saveSessionKeySerialized(
     keyId: string,
     keySerialized: Buffer,
-    privateAddress: string,
-    peerPrivateAddress?: string,
+    nodeId: string,
+    peerId?: string,
   ): Promise<void> {
     const privateKey = await this.sessionKeyRepository.create({
       derSerialization: keySerialized,
       id: keyId,
-      nodeId: privateAddress,
-      peerId: peerPrivateAddress,
+      nodeId,
+      peerId,
     });
     await this.sessionKeyRepository.save(privateKey);
   }

--- a/src/lib/DBPublicKeyStore.ts
+++ b/src/lib/DBPublicKeyStore.ts
@@ -14,19 +14,17 @@ export class DBPublicKeyStore extends PublicKeyStore {
 
   protected override async saveIdentityKeySerialized(
     keySerialized: Buffer,
-    peerPrivateAddress: string,
+    peerId: string,
   ): Promise<void> {
     const publicKey = await this.identityKeyRepository.create({
       derSerialization: keySerialized,
-      peerPrivateAddress,
+      peerId,
     });
     await this.identityKeyRepository.save(publicKey);
   }
 
-  protected override async retrieveIdentityKeySerialized(
-    peerPrivateAddress: string,
-  ): Promise<Buffer | null> {
-    const publicKey = await this.identityKeyRepository.findOne({ where: { peerPrivateAddress } });
+  protected override async retrieveIdentityKeySerialized(peerId: string): Promise<Buffer | null> {
+    const publicKey = await this.identityKeyRepository.findOne({ where: { peerId } });
     if (publicKey) {
       return publicKey.derSerialization;
     }
@@ -35,21 +33,21 @@ export class DBPublicKeyStore extends PublicKeyStore {
 
   protected override async saveSessionKeyData(
     keyData: SessionPublicKeyData,
-    peerPrivateAddress: string,
+    peerId: string,
   ): Promise<void> {
     const publicKey = await this.sessionRepository.create({
       creationDate: keyData.publicKeyCreationTime,
       derSerialization: keyData.publicKeyDer,
       id: keyData.publicKeyId,
-      peerPrivateAddress,
+      peerId,
     });
     await this.sessionRepository.save(publicKey);
   }
 
   protected override async retrieveSessionKeyData(
-    peerPrivateAddress: string,
+    peerId: string,
   ): Promise<SessionPublicKeyData | null> {
-    const publicKey = await this.sessionRepository.findOne({ where: { peerPrivateAddress } });
+    const publicKey = await this.sessionRepository.findOne({ where: { peerId } });
     if (publicKey) {
       return {
         publicKeyCreationTime: publicKey.creationDate,

--- a/src/lib/entities/Certificate.ts
+++ b/src/lib/entities/Certificate.ts
@@ -7,11 +7,11 @@ export class Certificate {
 
   @Index()
   @Column()
-  public readonly subjectPrivateAddress!: string;
+  public readonly subjectId!: string;
 
   @Index()
   @Column()
-  public readonly issuerPrivateAddress!: string;
+  public readonly issuerId!: string;
 
   @Column()
   public readonly serialization!: Buffer;

--- a/src/lib/entities/IdentityPublicKey.ts
+++ b/src/lib/entities/IdentityPublicKey.ts
@@ -3,7 +3,7 @@ import { Column, Entity, PrimaryColumn } from 'typeorm';
 @Entity()
 export class IdentityPublicKey {
   @PrimaryColumn()
-  public readonly peerPrivateAddress!: string;
+  public readonly peerId!: string;
 
   @Column()
   public readonly derSerialization!: Buffer;

--- a/src/lib/entities/SessionPublicKey.ts
+++ b/src/lib/entities/SessionPublicKey.ts
@@ -3,7 +3,7 @@ import { Column, Entity, PrimaryColumn } from 'typeorm';
 @Entity()
 export class SessionPublicKey {
   @PrimaryColumn()
-  public readonly peerPrivateAddress!: string;
+  public readonly peerId!: string;
 
   @Column()
   public readonly id!: Buffer;


### PR DESCRIPTION
To "id".

Failed to do this as part of https://github.com/relaycorp/keystore-db-js/pull/165